### PR TITLE
Fixes handling of custom discovery messages in an incorrect security context.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/events/DiscoveryCustomEvent.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/events/DiscoveryCustomEvent.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.events;
 
+import java.util.UUID;
 import org.apache.ignite.events.DiscoveryEvent;
 import org.apache.ignite.internal.managers.discovery.DiscoveryCustomMessage;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
@@ -49,6 +50,9 @@ public class DiscoveryCustomEvent extends DiscoveryEvent {
 
     /** Affinity topology version. */
     private AffinityTopologyVersion affTopVer;
+
+    /** The ID of the security subject that initiated the custom discovery message to which this event belongs. */
+    private UUID secSubjId;
 
     /**
      * Default constructor.
@@ -83,6 +87,19 @@ public class DiscoveryCustomEvent extends DiscoveryEvent {
      */
     public void affinityTopologyVersion(AffinityTopologyVersion affTopVer) {
         this.affTopVer = affTopVer;
+    }
+
+    /**
+     * Gets the ID of the security subject that initiated the custom discovery message to which this event belongs.
+     * {@code null} if security is disabled.
+      */
+    @Nullable public UUID securitySubjectId() {
+        return secSubjId;
+    }
+
+    /** Sets the ID of the security subject that initiated the custom discovery message to which this event belongs. */
+    public void securitySubjectId(UUID secSubjId) {
+        this.secSubjId = secSubjId;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/SecurityAwareCustomMessageWrapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/SecurityAwareCustomMessageWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.managers.discovery;
+
+import java.util.UUID;
+import org.apache.ignite.spi.discovery.DiscoverySpiCustomMessage;
+import org.jetbrains.annotations.Nullable;
+
+/** Extends {@link CustomMessageWrapper} with ID of security subject that initiated the current message. */
+public class SecurityAwareCustomMessageWrapper extends CustomMessageWrapper {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** Security subject ID. */
+    private final UUID secSubjId;
+
+    /** */
+    public SecurityAwareCustomMessageWrapper(DiscoveryCustomMessage delegate, UUID secSubjId) {
+        super(delegate);
+
+        this.secSubjId = secSubjId;
+    }
+
+    /** Gets security Subject ID. */
+    public UUID securitySubjectId() {
+        return secSubjId;
+    }
+
+    /** {@inheritDoc} */
+    @Override public @Nullable DiscoverySpiCustomMessage ackMessage() {
+        DiscoveryCustomMessage ack = delegate().ackMessage();
+
+        return ack == null ? null : new SecurityAwareCustomMessageWrapper(ack, secSubjId);
+    }
+}
+

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/discovery/DiscoveryCustomMessageSecurityContextTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/discovery/DiscoveryCustomMessageSecurityContextTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.security.discovery;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.events.DiscoveryCustomEvent;
+import org.apache.ignite.internal.managers.discovery.DiscoCache;
+import org.apache.ignite.internal.managers.discovery.DiscoveryCustomMessage;
+import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
+import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
+import org.apache.ignite.internal.processors.security.AbstractSecurityTest;
+import org.apache.ignite.internal.processors.security.OperationSecurityContext;
+import org.apache.ignite.internal.processors.security.SecurityContext;
+import org.apache.ignite.lang.IgniteUuid;
+import org.apache.ignite.plugin.security.AuthenticationContext;
+import org.apache.ignite.plugin.security.SecurityCredentials;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.ignite.internal.events.DiscoveryCustomEvent.EVT_DISCOVERY_CUSTOM_EVT;
+
+/**
+ * Tests that discovery custom message processing is performed on the remote nodes in the same security context in
+ * which message was sent.
+ */
+public class DiscoveryCustomMessageSecurityContextTest extends AbstractSecurityTest {
+    /** */
+    private static final UUID TEST_SECURITY_SUBJECT_ID = UUID.randomUUID();
+
+    /** */
+    @Test
+    public void testCustomMessageSecurityContext() throws Exception {
+        // 12 = 3 nodes in cluster * (1 msg + 1 ack) * 2 (msg sending is performed twice from server and client node).
+        CountDownLatch msgSecCtxCheckedLatch = new CountDownLatch(12);
+        CountDownLatch evtSecCtxCheckedLatch = new CountDownLatch(12);
+
+        IgniteEx crd = startGrid(0, false, msgSecCtxCheckedLatch, evtSecCtxCheckedLatch);
+
+        IgniteEx srv = startGrid(1, false, msgSecCtxCheckedLatch, evtSecCtxCheckedLatch);
+
+        IgniteEx cli = startGrid(2, true, msgSecCtxCheckedLatch, evtSecCtxCheckedLatch);
+
+        AuthenticationContext authCtx = new AuthenticationContext();
+
+        authCtx.subjectId(TEST_SECURITY_SUBJECT_ID);
+        authCtx.credentials(new SecurityCredentials("test", ""));
+
+        SecurityContext secCtx = crd.context().security().authenticate(authCtx);
+
+        assertEquals(TEST_SECURITY_SUBJECT_ID, secCtx.subject().id());
+
+        try (OperationSecurityContext ignored = cli.context().security().withContext(TEST_SECURITY_SUBJECT_ID)) {
+            cli.context().discovery().sendCustomEvent(new TestCustomMessage());
+        }
+
+        try (OperationSecurityContext ignored = srv.context().security().withContext(TEST_SECURITY_SUBJECT_ID)) {
+            srv.context().discovery().sendCustomEvent(new TestCustomMessage());
+        }
+
+        assertTrue(msgSecCtxCheckedLatch.await(getTestTimeout(), MILLISECONDS));
+        assertTrue(evtSecCtxCheckedLatch.await(getTestTimeout(), MILLISECONDS));
+    }
+
+    /**
+     * Starts an Ignite node with custom discovery message and event listeners that checks the security context in
+     * which processing is performed and decrement corresponding latch.
+     */
+    private IgniteEx startGrid(
+        int idx,
+        boolean isClient,
+        CountDownLatch msgSecCtxCheckedLatch,
+        CountDownLatch evtSecCtxCheckedLatch
+    ) throws Exception {
+        String login = getTestIgniteInstanceName(idx);
+
+        IgniteEx ignite = isClient ? startClientAllowAll(login) : startGridAllowAll(login);
+
+        GridKernalContext ctx = ignite.context();
+
+        ctx.discovery().setCustomEventListener(TestCustomMessage.class,
+            (topVer, snd, msg) -> {
+                assertEquals(TEST_SECURITY_SUBJECT_ID, ctx.security().securityContext().subject().id());
+
+                msgSecCtxCheckedLatch.countDown();
+            });
+
+        ctx.discovery().setCustomEventListener(TestCustomAckMessage.class,
+            (topVer, snd, msg) -> {
+                assertEquals(TEST_SECURITY_SUBJECT_ID, ctx.security().securityContext().subject().id());
+
+                msgSecCtxCheckedLatch.countDown();
+            });
+
+        ignite.events().localListen(e -> {
+            if (!(e instanceof DiscoveryCustomEvent))
+                return true;
+
+            DiscoveryCustomEvent customEvt = (DiscoveryCustomEvent)e;
+
+            DiscoveryCustomMessage customMsg = customEvt.customMessage();
+
+            if (customMsg instanceof TestCustomMessage || customMsg instanceof TestCustomAckMessage) {
+                assertEquals(TEST_SECURITY_SUBJECT_ID, customEvt.securitySubjectId());
+
+                evtSecCtxCheckedLatch.countDown();
+            }
+
+            return true;
+        }, EVT_DISCOVERY_CUSTOM_EVT);
+
+        return ignite;
+    }
+
+    /** */
+    private static class TestCustomAckMessage implements DiscoveryCustomMessage {
+        /** {@inheritDoc} */
+        @Override public IgniteUuid id() {
+            return IgniteUuid.randomUuid();
+        }
+
+        /** {@inheritDoc} */
+        @Override public @Nullable DiscoveryCustomMessage ackMessage() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean isMutable() {
+            return false;
+        }
+
+        /** {@inheritDoc} */
+        @Override public DiscoCache createDiscoCache(
+            GridDiscoveryManager mgr,
+            AffinityTopologyVersion topVer,
+            DiscoCache discoCache
+        ) {
+            return null;
+        }
+    }
+
+    /** */
+    private static class TestCustomMessage implements DiscoveryCustomMessage {
+        /** {@inheritDoc} */
+        @Override public IgniteUuid id() {
+            return IgniteUuid.randomUuid();
+        }
+
+        /** {@inheritDoc} */
+        @Override public @Nullable DiscoveryCustomMessage ackMessage() {
+            return new TestCustomAckMessage();
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean isMutable() {
+            return false;
+        }
+
+        /** {@inheritDoc} */
+        @Override public DiscoCache createDiscoCache(
+            GridDiscoveryManager mgr,
+            AffinityTopologyVersion topVer,
+            DiscoCache discoCache
+        ) {
+            return null;
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestCertificateSecurityProcessor.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestCertificateSecurityProcessor.java
@@ -54,6 +54,9 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
     /** Permissions. */
     public static final Map<String, SecurityPermissionSet> PERMS = new ConcurrentHashMap<>();
 
+    /** Key - security subject ID, value - security contexts referred to this security subject. */
+    private final Map<UUID, SecurityContext> secCtxs = new ConcurrentHashMap<>();
+
     /** Users security data. */
     private final Collection<TestSecurityData> predefinedAuthData;
 
@@ -70,7 +73,7 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
 
     /** {@inheritDoc} */
     @Override public SecurityContext authenticateNode(ClusterNode node, SecurityCredentials cred) {
-        return new TestSecurityContext(
+        SecurityContext res = new TestSecurityContext(
             new TestSecuritySubject()
                 .setType(REMOTE_NODE)
                 .setId(node.id())
@@ -78,6 +81,10 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
                 .setLogin("")
                 .setPerms(ALLOW_ALL)
         );
+
+        secCtxs.put(res.subject().id(), res);
+
+        return res;
     }
 
     /** {@inheritDoc} */
@@ -101,7 +108,7 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
         if (!PERMS.containsKey(cn))
             return null;
 
-        return new TestSecurityContext(
+        SecurityContext res = new TestSecurityContext(
             new TestSecuritySubject()
                 .setType(ctx.subjectType())
                 .setId(ctx.subjectId())
@@ -110,6 +117,10 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
                 .setPerms(PERMS.get(cn))
                 .setCerts(ctx.certificates())
         );
+
+        secCtxs.put(res.subject().id(), res);
+
+        return res;
     }
 
     /** {@inheritDoc} */
@@ -120,6 +131,11 @@ public class TestCertificateSecurityProcessor extends GridProcessorAdapter imple
     /** {@inheritDoc} */
     @Override public SecuritySubject authenticatedSubject(UUID subjId) {
         return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override public SecurityContext securityContext(UUID subjId) {
+        return secCtxs.get(subjId);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestReconnectProcessor.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestReconnectProcessor.java
@@ -71,6 +71,11 @@ public class TestReconnectProcessor extends GridProcessorAdapter implements Grid
     }
 
     /** {@inheritDoc} */
+    @Override public SecurityContext securityContext(UUID subjId) {
+        return new TestSecurityContext(new TestSecuritySubject(subjId));
+    }
+
+    /** {@inheritDoc} */
     @Override public Collection<SecuritySubject> authenticatedSubjects() throws IgniteCheckedException {
         return null;
     }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/SecurityTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/SecurityTestSuite.java
@@ -44,6 +44,7 @@ import org.apache.ignite.internal.processors.security.compute.closure.Distribute
 import org.apache.ignite.internal.processors.security.compute.closure.ExecutorServiceRemoteSecurityContextCheckTest;
 import org.apache.ignite.internal.processors.security.datastreamer.DataStreamerPermissionCheckTest;
 import org.apache.ignite.internal.processors.security.datastreamer.closure.DataStreamerRemoteSecurityContextCheckTest;
+import org.apache.ignite.internal.processors.security.discovery.DiscoveryCustomMessageSecurityContextTest;
 import org.apache.ignite.internal.processors.security.events.EventsRemoteSecurityContextCheckTest;
 import org.apache.ignite.internal.processors.security.messaging.MessagingRemoteSecurityContextCheckTest;
 import org.apache.ignite.internal.processors.security.sandbox.AccessToClassesInsideInternalPackageTest;
@@ -122,7 +123,8 @@ import org.junit.runners.Suite;
     SchedulerSandboxTest.class,
 
     IgniteSecurityProcessorTest.class,
-    MultipleSSLContextsTest.class
+    MultipleSSLContextsTest.class,
+    DiscoveryCustomMessageSecurityContextTest.class
 })
 public class SecurityTestSuite {
     /** */

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/ZookeeperDiscoverySpiTestSuite4.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/ZookeeperDiscoverySpiTestSuite4.java
@@ -26,6 +26,7 @@ import org.apache.ignite.internal.processors.cache.distributed.replicated.GridCa
 import org.apache.ignite.internal.processors.cache.distributed.replicated.IgniteCacheReplicatedQuerySelfTest;
 import org.apache.ignite.internal.processors.metastorage.DistributedMetaStoragePersistentTest;
 import org.apache.ignite.internal.processors.metastorage.DistributedMetaStorageTest;
+import org.apache.ignite.internal.processors.security.discovery.DiscoveryCustomMessageSecurityContextTest;
 import org.apache.ignite.spi.discovery.DiscoverySpiDataExchangeTest;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -46,7 +47,8 @@ import org.junit.runners.Suite;
     DistributedMetaStorageTest.class,
     DistributedMetaStoragePersistentTest.class,
     IgniteNodeValidationFailedEventTest.class,
-    DiscoverySpiDataExchangeTest.class
+    DiscoverySpiDataExchangeTest.class,
+    DiscoveryCustomMessageSecurityContextTest.class
 })
 public class ZookeeperDiscoverySpiTestSuite4 {
     /** */


### PR DESCRIPTION
The current PR fixes handling of custom discovery messages in an incorrect security context on remote nodes.

It introduces CustomMessageSecurityAwareWrapper that stores security context that is caught before message sending and is restored after message is received.
Adds security subject id that belongs to actual message initiator to DiscoveryCustomEvent.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
